### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -25,20 +25,20 @@ toFahrenheit	KEYWORD2
 toCelsius	KEYWORD2
 computeHeatIndex	KEYWORD2
 computeDewPoint	KEYWORD2
-getComfortRatio KEYWORD2
-getNumberOfDecimalsTemperature KEYWORD2
-getLowerBoundTemperature KEYWORD2
-getUpperBoundTemperature KEYWORD2
-getNumberOfDecimalsHumidity KEYWORD2
-getLowerBoundHumidity KEYWORD2
-getUpperBoundHumidity KEYWORD2
-getComfortProfile KEYWORD2
-setComfortProfile KEYWORD2
-isTooHot KEYWORD2
-isTooHumid KEYWORD2
-isTooCold KEYWORD2
-isTooDry KEYWORD2
-computePerception KEYWORD2
+getComfortRatio	KEYWORD2
+getNumberOfDecimalsTemperature	KEYWORD2
+getLowerBoundTemperature	KEYWORD2
+getUpperBoundTemperature	KEYWORD2
+getNumberOfDecimalsHumidity	KEYWORD2
+getLowerBoundHumidity	KEYWORD2
+getUpperBoundHumidity	KEYWORD2
+getComfortProfile	KEYWORD2
+setComfortProfile	KEYWORD2
+isTooHot	KEYWORD2
+isTooHumid	KEYWORD2
+isTooCold	KEYWORD2
+isTooDry	KEYWORD2
+computePerception	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords